### PR TITLE
match npm version scheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t3st",
-  "version": "2024.05.28",
+  "version": "2024.5.28",
   "description": "A minimal javascript test framework",
   "files": [
     "/bin",


### PR DESCRIPTION
npm output for "npm view t3st version" removes leading zeros in version numbers.